### PR TITLE
Removed requirement of context containing trailing slash

### DIFF
--- a/config.js
+++ b/config.js
@@ -68,6 +68,23 @@ var config = {
           }
         ]
       },
+      serviceOverride: {
+        host: "127.0.0.1",
+        port: 9998,
+        proxy: true,
+        headers: {
+          RemoteUser: 'otheruser2'
+        },
+        proxies: [
+          {
+            context: "/test1\/service2\/v3\/service",
+            rewrite: {
+              from: "^/test1/service2",
+              to: ""
+            }
+          }
+        ]
+      },
       other: {
         host: "127.0.0.1",
         port: 9999,

--- a/server/middleware/proxy.js
+++ b/server/middleware/proxy.js
@@ -71,7 +71,7 @@ module.exports = function proxy() {
   return function(req, res, next) {
 
     var proxyConfig = _.find(cache, function(config) {
-      return req.url.match(new RegExp('^\\' + config.context + '\/.*'));
+      return req.url.match(new RegExp('^\\' + config.context + '.*'));
     });
 
     if(proxyConfig) {

--- a/server/middleware/tests/proxy.spec.js
+++ b/server/middleware/tests/proxy.spec.js
@@ -14,21 +14,25 @@ describe('Proxy', function() {
   var server1;
   var proxy2;
   var server2;
+  var proxy3;
+  var server3;
 
   before(function() {
     config.testing.servers.api.proxy = true;
     config.testing.servers.other.proxy = true;
+    config.testing.servers.serviceOverride.proxy = true;
   });
 
   after(function() {
     config.testing.servers.api.proxy = false;
     config.testing.servers.other.proxy = false;
+    config.testing.servers.serviceOverride.proxy = false;
   });
 
   beforeEach(function(done) {
     var express = require('express');
 
-    var finished = _.after(2, function() {
+    var finished = _.after(3, function() {
       done();
     });
 
@@ -59,14 +63,21 @@ describe('Proxy', function() {
       res.json(body);
     });
 
+    proxy3 = express();
+
+    proxy3.get('/v3/service', function(req, res) {
+      res.json({x: 34});
+    });
+
     server1 = proxy1.listen(config.testing.servers.api.port, finished);
     server2 = proxy2.listen(config.testing.servers.other.port, finished);
+    server3 = proxy3.listen(config.testing.servers.serviceOverride.port, finished);
 
   });
 
   afterEach(function(done) {
 
-    var finished = _.after(2, function() {
+    var finished = _.after(3, function() {
       done();
     });
 
@@ -78,6 +89,12 @@ describe('Proxy', function() {
 
     if(server2 && server2.close) {
       server2.close(finished);
+    } else {
+      finished();
+    }
+
+    if(server3 && server3.close) {
+      server3.close(finished);
     } else {
       finished();
     }
@@ -140,6 +157,16 @@ describe('Proxy', function() {
       .end(function (err, res) {
         expect(err).to.be.null;
         expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('should select finer grained route', function(done) {
+    request.get(helper.getUrl('/test1/service2/v3/service'))
+      .end(function(err, res) {
+        expect(err).to.be.null;
+        expect(res.status).to.equal(200);
+        expect(_.isEqual(res.body, {'x': 34})).to.be.ok;
         done();
       });
   });


### PR DESCRIPTION
This allows for specific services in a particular context to be overridden.
