### PR TITLE
Fix proxy.md field name

### DIFF
--- a/docs/readme/partials/proxy.md
+++ b/docs/readme/partials/proxy.md
@@ -42,7 +42,7 @@ servers: {
         host: "127.0.0.1",
         port: 7777, // port number to proxied server
         proxy: true, // defaults to false.  when true the proxy is enabled
-        header: {
+        headers: {
             "userid": "johndoe" // set custom header for proxy requests to this server
         },
         proxies: 
@@ -80,7 +80,7 @@ servers: {
                     from: "^/api",
                     to: ""
                 },
-                header: {
+                headers: {
                     "userid": "johndoe" // set custom header for proxy requests this context for this server
                 }
             },


### PR DESCRIPTION
Change 'header' field to say 'headers' in documentation.
