### PR TITLE
Make ekko work through express middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,8 +17,7 @@ class Ekko {
     config.events = new events.EventEmitter();
   }
 
-  start(options) {
-
+  middleware(options) {
     config.path = this._configPath;
     config.set(options);
 
@@ -27,6 +26,13 @@ class Ekko {
 
     middleware.headers();
     middleware.config();
+
+    return config.router;
+  }
+
+  start(options) {
+
+    this.middleware(options);
 
     const port = config.options.port || 0;
     config.app.set('port', port);

--- a/server/middleware/config.js
+++ b/server/middleware/config.js
@@ -38,29 +38,29 @@ expressLogger.token('avStatus', function getStatusToken(req, res) {
 module.exports = function development() {
 
   if (Logger.canLog()) {
-    config.app.use(expressLogger(':prefix :avMethod :url :avStatus :response-time'));
+    config.router.use(expressLogger(':prefix :avMethod :url :avStatus :response-time'));
   }
 
-  config.app.use(requestHandler());
-  config.app.use(errorhandler());
-  config.app.use(compression());
-  config.app.use(cors());
+  config.router.use(requestHandler());
+  config.router.use(errorhandler());
+  config.router.use(compression());
+  config.router.use(cors());
 
   // pretty print json
   config.app.set('json spaces', 2);
 
-  config.app.use(methodOverride('X-HTTP-Method-Override'));
+  config.router.use(methodOverride('X-HTTP-Method-Override'));
 
-  config.app.use(bodyParser.json({
+  config.router.use(bodyParser.json({
     limit: _.get(config, 'options.limit', '50mb')
   })); // parse application/json
 
-  config.app.use(bodyParser.urlencoded({
+  config.router.use(bodyParser.urlencoded({
     extended: true,
     limit: config.options.limit
   })); // // parse application/x-www-form-urlencoded
 
-  config.app.use(busboy({ immediate: false }));
+  config.router.use(busboy({ immediate: false }));
 
   config.app.use('/', config.router);
   config.app.use('/api', config.router);

--- a/server/routes/tests/routes-spec.js
+++ b/server/routes/tests/routes-spec.js
@@ -22,6 +22,9 @@ describe('Routes', () => {
       const routeConfigs = ekko.config().router.stack;
 
       const _verbs = _.chain(routeConfigs)
+        .filter((routeConfig) => {
+          return routeConfig.route !== undefined;
+        })
         .map((routeConfig) => {
           if (routeConfig.route.path === path) {
             return _.keys(routeConfig.route.methods)[0];


### PR DESCRIPTION
This allows ekko to be used as express middleware. This is useful for 'dev servers' where express is only there for development and such and will not be used in production (since you wouldn't really want ekko in production)
Added new `middleware` method on the instance of `Ekko` which can be passed to express's `use`:
```javascript
// because you are using express, you would already be importing these
const express = require('express');
const app = express();

// This is the same as the stand-alone server use.
const Ekko = require('availity-ekko');
const ekko = new Ekko(/*optional configPath, same as before*/);

// *NEW* register the middleware in your existing express app.
app.use(ekko.middleware(/*optional options, same as `start`*/));

// because you are using express, you would already have something like this
app.listen(3001);
```

Review and if you like what you see, I'll add some docs to the PR.